### PR TITLE
Fix release artifact reconstruction

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -311,30 +311,10 @@ jobs:
           python3 tools/update_failed_versions.py \
             --failed-json public/failed.json --add-file _all_failed.txt
       - name: Reconstruct per-version dirs
-        run: |
-          set -e
-          mkdir -p stage
-          find downloaded -type f \( -name d8 -o -name d8.exe \) | while read -r bin; do
-            base=$(basename "$(dirname "$bin")")
-            ver="${base#d8-}"
-            if echo "$base" | grep -q "\-Linux$"; then
-              ver="${ver%-Linux}"
-              tgt="stage/d8-${ver}-Linux"
-              mkdir -p "$tgt"
-              cp "$bin" "$tgt/d8"
-              rep_dir=$(dirname "$bin")
-              [ -f "$rep_dir/snapshot_blob.bin" ] && cp "$rep_dir/snapshot_blob.bin" "$tgt/snapshot_blob.bin"
-              [ -f "$rep_dir/apply_patch_report.txt" ] && cp "$rep_dir/apply_patch_report.txt" "$tgt/"
-            elif echo "$base" | grep -q "\-Windows$"; then
-              ver="${ver%-Windows}"
-              tgt="stage/d8-${ver}-Windows"
-              mkdir -p "$tgt"
-              cp "$bin" "$tgt/d8.exe"
-              rep_dir=$(dirname "$bin")
-              [ -f "$rep_dir/snapshot_blob.bin" ] && cp "$rep_dir/snapshot_blob.bin" "$tgt/snapshot_blob.bin"
-              [ -f "$rep_dir/apply_patch_report.txt" ] && cp "$rep_dir/apply_patch_report.txt" "$tgt/"
-            fi
-          done
+        run: >-
+          python3 tools/reconstruct_release_artifacts.py
+          --input downloaded
+          --output stage
       - name: Create releases & update version.json
         env:
           ALL_VERSIONS: ${{ needs.determine-versions.outputs.versions_json }}

--- a/tests/test_release_aggregation.py
+++ b/tests/test_release_aggregation.py
@@ -1,0 +1,84 @@
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Optional
+
+from tools.reconstruct_release_artifacts import reconstruct_artifacts
+
+
+class ReleaseArtifactReconstructionTest(unittest.TestCase):
+    def create_artifact(
+        self,
+        downloaded: Path,
+        directory_name: str,
+        binary_name: str,
+        report_name: Optional[str] = None,
+    ) -> Path:
+        artifact = downloaded / "matrix-job" / "artifacts" / directory_name
+        artifact.mkdir(parents=True)
+        (artifact / binary_name).write_bytes(b"binary")
+        (artifact / "snapshot_blob.bin").write_bytes(b"snapshot")
+        if report_name:
+            (artifact / report_name).write_text("report\n", encoding="utf-8")
+        return artifact
+
+    def test_json_only_report_does_not_fail_reconstruction(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            downloaded = root / "downloaded"
+            stage = root / "stage"
+            self.create_artifact(
+                downloaded,
+                "d8-14.7.84-Linux",
+                "d8",
+                "apply_patch_report.json",
+            )
+
+            reconstructed = reconstruct_artifacts(downloaded, stage)
+
+            self.assertEqual(
+                [path.name for path in reconstructed], ["d8-14.7.84-Linux"]
+            )
+            target = stage / "d8-14.7.84-Linux"
+            self.assertEqual((target / "d8").read_bytes(), b"binary")
+            self.assertEqual(
+                (target / "snapshot_blob.bin").read_bytes(), b"snapshot"
+            )
+            self.assertTrue((target / "apply_patch_report.json").is_file())
+            self.assertFalse((target / "apply_patch_report.txt").exists())
+
+    def test_missing_optional_report_keeps_both_platforms(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            downloaded = root / "downloaded"
+            stage = root / "stage"
+            self.create_artifact(downloaded, "d8-10.8.168.25-Linux", "d8")
+            self.create_artifact(downloaded, "d8-10.8.168.25-Windows", "d8.exe")
+            unrelated = downloaded / "other" / "d8"
+            unrelated.parent.mkdir(parents=True)
+            unrelated.write_bytes(b"ignore me")
+
+            reconstructed = reconstruct_artifacts(downloaded, stage)
+
+            self.assertEqual(
+                {path.name for path in reconstructed},
+                {"d8-10.8.168.25-Linux", "d8-10.8.168.25-Windows"},
+            )
+            self.assertTrue((stage / "d8-10.8.168.25-Linux" / "d8").is_file())
+            self.assertTrue(
+                (stage / "d8-10.8.168.25-Windows" / "d8.exe").is_file()
+            )
+
+    def test_production_workflow_uses_the_tested_reconstructor(self):
+        workflow = (
+            Path(__file__).parents[1] / ".github" / "workflows" / "main.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("tools/reconstruct_release_artifacts.py", workflow)
+        self.assertNotIn(
+            '[ -f "$rep_dir/apply_patch_report.txt" ] && cp', workflow
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/reconstruct_release_artifacts.py
+++ b/tools/reconstruct_release_artifacts.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Reconstruct per-platform release directories from matrix artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+from pathlib import Path
+
+
+ARTIFACT_DIR_RE = re.compile(
+    r"^d8-(?P<version>\d+\.\d+\.\d+(?:\.\d+)?)-(?P<platform>Linux|Windows)$"
+)
+PLATFORM_BINARY = {"Linux": "d8", "Windows": "d8.exe"}
+COMPANION_FILES = (
+    "snapshot_blob.bin",
+    "apply_patch_report.txt",
+    "apply_patch_report.json",
+)
+
+
+def reconstruct_artifacts(input_dir: Path, output_dir: Path) -> list[Path]:
+    """Copy recognized matrix outputs into their release staging directories."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    reconstructed: list[Path] = []
+    seen: set[str] = set()
+
+    binaries = sorted(
+        path
+        for path in input_dir.rglob("*")
+        if path.is_file() and path.name in PLATFORM_BINARY.values()
+    )
+    for binary in binaries:
+        artifact_dir = binary.parent
+        match = ARTIFACT_DIR_RE.fullmatch(artifact_dir.name)
+        if match is None:
+            continue
+
+        platform_name = match.group("platform")
+        expected_binary = PLATFORM_BINARY[platform_name]
+        if binary.name != expected_binary:
+            raise RuntimeError(
+                f"Unexpected {platform_name} binary name in {artifact_dir}: "
+                f"expected {expected_binary}, found {binary.name}"
+            )
+        if artifact_dir.name in seen:
+            raise RuntimeError(f"Duplicate release artifact: {artifact_dir.name}")
+        seen.add(artifact_dir.name)
+
+        target_dir = output_dir / artifact_dir.name
+        target_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(binary, target_dir / expected_binary)
+        for name in COMPANION_FILES:
+            companion = artifact_dir / name
+            if companion.is_file():
+                shutil.copy2(companion, target_dir / name)
+
+        reconstructed.append(target_dir)
+        print(f"Reconstructed {artifact_dir.name}")
+
+    print(f"Reconstructed {len(reconstructed)} platform artifact directories.")
+    return reconstructed
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", type=Path, default=Path("downloaded"))
+    parser.add_argument("--output", type=Path, default=Path("stage"))
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    reconstruct_artifacts(args.input, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- replace the failure-prone shell artifact reconstruction loop with a tested Python helper
- preserve Linux and Windows binaries, snapshots, and either text or JSON patch reports
- add regression coverage for JSON-only and missing optional reports
- assert that the production workflow uses the tested helper

## Root cause

Run [#31447916816](https://github.com/xqy2006/jsc2js/actions/runs/31447916816) completed all 12 build jobs, then failed in `Reconstruct per-version dirs`. The loop's last optional check used `[ -f ... ] && cp ...`; when `apply_patch_report.txt` was absent (modern patches emit JSON), the loop returned status 1 and `set -e` terminated the release job before any release was created.

## Impact

The aggregate job no longer treats an absent optional report as a failure. It also carries both supported patch-report formats into staging.

## Validation

- `python -m unittest discover -s tests` — 84 passed
- Ruff passed for the new helper and tests
- Python bytecode compilation passed
- all 7 workflow YAML files parsed successfully
- the duplicate scheduled run was confirmed cancelled